### PR TITLE
Avoid repeated validation during encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-patches
 
+## v0.3.0
+- Further performance improvements for `Avro::SchemaValidator` and encoding.
+
 ## v0.2.0
 - Performance improvements for `Avro::SchemaValidator`.
 

--- a/lib/avro-patches/logical_types/io.rb
+++ b/lib/avro-patches/logical_types/io.rb
@@ -2,7 +2,7 @@ Avro::IO::DatumWriter.class_eval do
   def write_data(writers_schema, logical_datum, encoder)
     datum = writers_schema.type_adapter.encode(logical_datum)
 
-    unless Avro::Schema.validate_simple(writers_schema, datum, true)
+    unless Avro::Schema.validate(writers_schema, datum, false, true)
       raise Avro::IO::AvroTypeError.new(writers_schema, datum)
     end
 

--- a/lib/avro-patches/logical_types/io.rb
+++ b/lib/avro-patches/logical_types/io.rb
@@ -2,7 +2,7 @@ Avro::IO::DatumWriter.class_eval do
   def write_data(writers_schema, logical_datum, encoder)
     datum = writers_schema.type_adapter.encode(logical_datum)
 
-    unless Avro::Schema.validate(writers_schema, datum, encoded = true)
+    unless Avro::Schema.validate_simple(writers_schema, datum, encoded = true)
       raise Avro::IO::AvroTypeError.new(writers_schema, datum)
     end
 

--- a/lib/avro-patches/logical_types/io.rb
+++ b/lib/avro-patches/logical_types/io.rb
@@ -2,7 +2,7 @@ Avro::IO::DatumWriter.class_eval do
   def write_data(writers_schema, logical_datum, encoder)
     datum = writers_schema.type_adapter.encode(logical_datum)
 
-    unless Avro::Schema.validate_simple(writers_schema, datum, encoded = true)
+    unless Avro::Schema.validate_simple(writers_schema, datum, true)
       raise Avro::IO::AvroTypeError.new(writers_schema, datum)
     end
 

--- a/lib/avro-patches/logical_types/io.rb
+++ b/lib/avro-patches/logical_types/io.rb
@@ -2,7 +2,7 @@ Avro::IO::DatumWriter.class_eval do
   def write_data(writers_schema, logical_datum, encoder)
     datum = writers_schema.type_adapter.encode(logical_datum)
 
-    unless Avro::Schema.validate(writers_schema, datum, false, true)
+    unless Avro::Schema.validate(writers_schema, datum, { recursive: false, encoded: true })
       raise Avro::IO::AvroTypeError.new(writers_schema, datum)
     end
 

--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -57,20 +57,8 @@ Avro::Schema.class_eval do
   end
 
   # Determine if a ruby datum is an instance of a schema
-  def self.validate(expected_schema, logical_datum, encoded = false)
-    with_safe_validation do
-      Avro::SchemaValidator.validate!(expected_schema, logical_datum, encoded)
-    end
-  end
-
-  def self.validate_simple(expected_schema, logical_datum, encoded = false)
-    with_safe_validation do
-      Avro::SchemaValidator.validate_simple!(expected_schema, logical_datum, encoded)
-    end
-  end
-
-  def self.with_safe_validation
-    yield
+  def self.validate(expected_schema, logical_datum, recursive = true, encoded = false)
+    Avro::SchemaValidator.validate!(expected_schema, logical_datum, recursive, encoded)
     true
   rescue Avro::SchemaValidator::ValidationError
     false

--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -57,8 +57,8 @@ Avro::Schema.class_eval do
   end
 
   # Determine if a ruby datum is an instance of a schema
-  def self.validate(expected_schema, logical_datum, recursive = true, encoded = false)
-    Avro::SchemaValidator.validate!(expected_schema, logical_datum, recursive, encoded)
+  def self.validate(expected_schema, logical_datum, options = { recursive: true, encoded: false })
+    Avro::SchemaValidator.validate!(expected_schema, logical_datum, options)
     true
   rescue Avro::SchemaValidator::ValidationError
     false

--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -58,7 +58,19 @@ Avro::Schema.class_eval do
 
   # Determine if a ruby datum is an instance of a schema
   def self.validate(expected_schema, logical_datum, encoded = false)
-    Avro::SchemaValidator.validate!(expected_schema, logical_datum, encoded)
+    with_safe_validation do
+      Avro::SchemaValidator.validate!(expected_schema, logical_datum, encoded)
+    end
+  end
+
+  def self.validate_simple(expected_schema, logical_datum, encoded = false)
+    with_safe_validation do
+      Avro::SchemaValidator.validate_simple!(expected_schema, logical_datum, encoded)
+    end
+  end
+
+  def self.with_safe_validation
+    yield
     true
   rescue Avro::SchemaValidator::ValidationError
     false

--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -1,24 +1,21 @@
 module AvroPatches
   module LogicalTypes
     module SchemaValidatorPatch
-      def validate!(expected_schema, logical_datum, encoded = false)
-        with_result do |result|
+      def validate!(expected_schema, logical_datum, recursive = true, encoded = false)
+        result = Avro::SchemaValidator::Result.new
+        if recursive
           validate_recursive(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
-        end
-      end
-
-      def validate_simple!(expected_schema, logical_datum, encoded = false)
-        with_result do |result|
+        else
           validate_simple(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
         end
+        fail Avro::SchemaValidator::ValidationError, result if result.failure?
+        result
       end
 
       private
 
       def validate_recursive(expected_schema, logical_datum, path, result, encoded = false)
         datum = resolve_datum(expected_schema, logical_datum, encoded)
-
-        validate_type(expected_schema)
 
         # The entire method is overridden so that encoded: true can be passed here
         validate_simple(expected_schema, datum, path, result, true)

--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -1,12 +1,15 @@
 module AvroPatches
   module LogicalTypes
     module SchemaValidatorPatch
-      def validate!(expected_schema, logical_datum, recursive = true, encoded = false)
+      def validate!(expected_schema, logical_datum, options = { recursive: true, encoded: false })
+        options ||= {}
+        options[:recursive] = true unless options.key?(:recursive)
+
         result = Avro::SchemaValidator::Result.new
-        if recursive
-          validate_recursive(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
+        if options[:recursive]
+          validate_recursive(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, options[:encoded])
         else
-          validate_simple(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
+          validate_simple(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, options[:encoded])
         end
         fail Avro::SchemaValidator::ValidationError, result if result.failure?
         result

--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -2,22 +2,56 @@ module AvroPatches
   module LogicalTypes
     module SchemaValidatorPatch
       def validate!(expected_schema, logical_datum, encoded = false)
-        result = Avro::SchemaValidator::Result.new
-        validate_recursive(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
-        fail Avro::SchemaValidator::ValidationError, result if result.failure?
-        result
+        with_result do |result|
+          validate_recursive(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
+        end
+      end
+
+      def validate_simple!(expected_schema, logical_datum, encoded = false)
+        with_result do |result|
+          validate_simple(expected_schema, logical_datum, Avro::SchemaValidator::ROOT_IDENTIFIER, result, encoded)
+        end
       end
 
       private
 
       def validate_recursive(expected_schema, logical_datum, path, result, encoded = false)
-        datum = if encoded
-                  logical_datum
-                else
-                  expected_schema.type_adapter.encode(logical_datum) rescue nil
-                end
+        datum = resolve_datum(expected_schema, logical_datum, encoded)
 
+        validate_type(expected_schema)
+
+        # The entire method is overridden so that encoded: true can be passed here
+        validate_simple(expected_schema, datum, path, result, true)
+
+        case expected_schema.type_sym
+        when :array
+          validate_array(expected_schema, datum, path, result)
+        when :map
+          validate_map(expected_schema, datum, path, result)
+        when :union
+          validate_union(expected_schema, datum, path, result)
+        when :record, :error, :request
+          fail Avro::SchemaValidator::TypeMismatchError unless datum.is_a?(Hash)
+          expected_schema.fields.each do |field|
+            deeper_path = deeper_path_for_hash(field.name, path)
+            validate_recursive(field.type, datum[field.name], deeper_path, result)
+          end
+        end
+      rescue Avro::SchemaValidator::TypeMismatchError
+        result.add_error(path, "expected type #{expected_schema.type_sym}, got #{actual_value_message(datum)}")
+      end
+
+      def validate_simple(expected_schema, logical_datum, path, result, encoded = false)
+        datum = resolve_datum(expected_schema, logical_datum, encoded)
         super(expected_schema, datum, path, result)
+      end
+
+      def resolve_datum(expected_schema, logical_datum, encoded)
+        if encoded
+          logical_datum
+        else
+          expected_schema.type_adapter.encode(logical_datum) rescue nil
+        end
       end
     end
   end

--- a/lib/avro-patches/schema_validator/schema.rb
+++ b/lib/avro-patches/schema_validator/schema.rb
@@ -1,7 +1,7 @@
 Avro::Schema.class_eval do
   # Determine if a ruby datum is an instance of a schema
-  def self.validate(expected_schema, datum, recursive = true)
-    Avro::SchemaValidator.validate!(expected_schema, datum, recursive)
+  def self.validate(expected_schema, datum, options = { recursive: true })
+    Avro::SchemaValidator.validate!(expected_schema, datum, options)
     true
   rescue Avro::SchemaValidator::ValidationError
     false

--- a/lib/avro-patches/schema_validator/schema.rb
+++ b/lib/avro-patches/schema_validator/schema.rb
@@ -1,7 +1,7 @@
 Avro::Schema.class_eval do
   # Determine if a ruby datum is an instance of a schema
-  def self.validate(expected_schema, datum)
-    Avro::SchemaValidator.validate!(expected_schema, datum)
+  def self.validate(expected_schema, datum, recursive = true)
+    Avro::SchemaValidator.validate!(expected_schema, datum, recursive)
     true
   rescue Avro::SchemaValidator::ValidationError
     false

--- a/lib/avro-patches/schema_validator/schema_validator.rb
+++ b/lib/avro-patches/schema_validator/schema_validator.rb
@@ -64,15 +64,55 @@ module Avro
 
     class << self
       def validate!(expected_schema, datum)
-        result = Result.new
-        validate_recursive(expected_schema, datum, ROOT_IDENTIFIER, result)
-        fail ValidationError, result if result.failure?
-        result
+        with_result do |result|
+          validate_recursive(expected_schema, datum, ROOT_IDENTIFIER, result)
+        end
+      end
+
+      def validate_simple!(expected_schema, datum)
+        with_result do |result|
+          validate_simple(expected_schema, datum, ROOT_IDENTIFIER, result)
+        end
       end
 
       private
 
+      def with_result
+        result = Avro::SchemaValidator::Result.new
+        yield result
+        fail Avro::SchemaValidator::ValidationError, result if result.failure?
+        result
+      end
+
+      def validate_type(expected_schema)
+        unless Avro::Schema::VALID_TYPES_SYM.include?(expected_schema.type_sym)
+          fail "Unexpected schema type #{expected_schema.type_sym} #{expected_schema.inspect}"
+        end
+      end
+
       def validate_recursive(expected_schema, datum, path, result)
+        validate_type(expected_schema)
+        validate_simple(expected_schema, datum, path, result)
+
+        case expected_schema.type_sym
+        when :array
+          validate_array(expected_schema, datum, path, result)
+        when :map
+          validate_map(expected_schema, datum, path, result)
+        when :union
+          validate_union(expected_schema, datum, path, result)
+        when :record, :error, :request
+          fail TypeMismatchError unless datum.is_a?(Hash)
+          expected_schema.fields.each do |field|
+            deeper_path = deeper_path_for_hash(field.name, path)
+            validate_recursive(field.type, datum[field.name], deeper_path, result)
+          end
+        end
+      rescue TypeMismatchError
+        result.add_error(path, "expected type #{expected_schema.type_sym}, got #{actual_value_message(datum)}")
+      end
+
+      def validate_simple(expected_schema, datum, path, result = Result.new)
         case expected_schema.type_sym
         when :null
           fail TypeMismatchError unless datum.nil?
@@ -96,20 +136,6 @@ module Avro
           end
         when :enum
           result.add_error(path, enum_message(expected_schema.symbols, datum)) unless expected_schema.symbols.include?(datum)
-        when :array
-          validate_array(expected_schema, datum, path, result)
-        when :map
-          validate_map(expected_schema, datum, path, result)
-        when :union
-          validate_union(expected_schema, datum, path, result)
-        when :record, :error, :request
-          fail TypeMismatchError unless datum.is_a?(Hash)
-          expected_schema.fields.each do |field|
-            deeper_path = deeper_path_for_hash(field.name, path)
-            validate_recursive(field.type, datum[field.name], deeper_path, result)
-          end
-        else
-          fail "Unexpected schema type #{expected_schema.type_sym} #{expected_schema.inspect}"
         end
       rescue TypeMismatchError
         result.add_error(path, "expected type #{expected_schema.type_sym}, got #{actual_value_message(datum)}")

--- a/lib/avro-patches/schema_validator/schema_validator.rb
+++ b/lib/avro-patches/schema_validator/schema_validator.rb
@@ -64,9 +64,12 @@ module Avro
 
     class << self
       # This method is replaced by code in AvroPatches::LogicalTypes::SchemaValidatorPatch.
-      def validate!(expected_schema, datum, recursive = true)
+      def validate!(expected_schema, datum, options = { recursive: true })
+        options ||= {}
+        options[:recursive] = true unless options.key?(:recursive)
+
         result = Avro::SchemaValidator::Result.new
-        if recursive
+        if options[:recursive]
           validate_recursive(expected_schema, datum, ROOT_IDENTIFIER, result)
         else
           validate_simple(expected_schema, datum, ROOT_IDENTIFIER, result)

--- a/lib/avro-patches/schema_validator/schema_validator.rb
+++ b/lib/avro-patches/schema_validator/schema_validator.rb
@@ -63,6 +63,7 @@ module Avro
     TypeMismatchError = Class.new(ValidationError)
 
     class << self
+      # These methods are replaced by code in AvroPatches::LogicalTypes::SchemaValidatorPatch.
       def validate!(expected_schema, datum)
         with_result do |result|
           validate_recursive(expected_schema, datum, ROOT_IDENTIFIER, result)
@@ -90,6 +91,9 @@ module Avro
         end
       end
 
+      # This method is replaced by code in AvroPatches::LogicalTypes::SchemaValidatorPatch.
+      # The patches are layered this way because SchemaValidator exists on
+      # avro's master branch but logical type support is still in PR.
       def validate_recursive(expected_schema, datum, path, result)
         validate_type(expected_schema)
         validate_simple(expected_schema, datum, path, result)

--- a/lib/avro-patches/version.rb
+++ b/lib/avro-patches/version.rb
@@ -1,3 +1,3 @@
 module AvroPatches
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -22,7 +22,7 @@ class TestSchema < Test::Unit::TestCase
   end
 
   def validate_simple!(schema, value)
-    Avro::SchemaValidator.validate!(schema, value, false)
+    Avro::SchemaValidator.validate!(schema, value, { recursive: false })
   end
 
   def hash_to_schema(hash)
@@ -43,13 +43,13 @@ class TestSchema < Test::Unit::TestCase
   def assert_valid_schema(schema, valid, invalid, simple = false)
     valid.each do |value|
       assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value) }
-      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, false) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, { recursive: false }) } if simple
     end
 
     invalid.each do |value|
       assert_raise { Avro::SchemaValidator.validate!(schema, value) }
       assert_raise { Avro::SchemaValidator.validate!(schema, value, false) } if simple
-      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, false) } unless simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, { recursive: false }) } unless simple
     end
   end
 

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -22,7 +22,7 @@ class TestSchema < Test::Unit::TestCase
   end
 
   def validate_simple!(schema, value)
-    Avro::SchemaValidator.validate_simple!(schema, value)
+    Avro::SchemaValidator.validate!(schema, value, false)
   end
 
   def hash_to_schema(hash)
@@ -43,13 +43,13 @@ class TestSchema < Test::Unit::TestCase
   def assert_valid_schema(schema, valid, invalid, simple = false)
     valid.each do |value|
       assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value) }
-      assert_nothing_raised { Avro::SchemaValidator.validate_simple!(schema, value) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, false) } if simple
     end
 
     invalid.each do |value|
       assert_raise { Avro::SchemaValidator.validate!(schema, value) }
-      assert_raise { Avro::SchemaValidator.validate_simple!(schema, value) } if simple
-      assert_nothing_raised { Avro::SchemaValidator.validate_simple!(schema, value) } unless simple
+      assert_raise { Avro::SchemaValidator.validate!(schema, value, false) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, false) } unless simple
     end
   end
 

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -21,6 +21,10 @@ class TestSchema < Test::Unit::TestCase
     Avro::SchemaValidator.validate!(schema, value)
   end
 
+  def validate_simple!(schema, value)
+    Avro::SchemaValidator.validate_simple!(schema, value)
+  end
+
   def hash_to_schema(hash)
     Avro::Schema.parse(hash.to_json)
   end
@@ -36,13 +40,16 @@ class TestSchema < Test::Unit::TestCase
     assert_equal(assert_messages.size, result_errors.size)
   end
 
-  def assert_valid_schema(schema, valid, invalid)
+  def assert_valid_schema(schema, valid, invalid, simple = false)
     valid.each do |value|
       assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value) }
+      assert_nothing_raised { Avro::SchemaValidator.validate_simple!(schema, value) } if simple
     end
 
     invalid.each do |value|
       assert_raise { Avro::SchemaValidator.validate!(schema, value) }
+      assert_raise { Avro::SchemaValidator.validate_simple!(schema, value) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate_simple!(schema, value) } unless simple
     end
   end
 
@@ -50,9 +57,14 @@ class TestSchema < Test::Unit::TestCase
     schema = hash_to_schema(type: 'null', name: 'name')
 
     assert_nothing_raised { validate!(schema, nil) }
+    assert_nothing_raised { validate_simple!(schema, nil) }
 
     assert_failed_validation('at . expected type null, got int with value 1') do
       validate!(schema, 1)
+    end
+
+    assert_failed_validation('at . expected type null, got int with value 1') do
+      validate_simple!(schema, 1)
     end
   end
 
@@ -61,6 +73,8 @@ class TestSchema < Test::Unit::TestCase
 
     assert_nothing_raised { validate!(schema, true) }
     assert_nothing_raised { validate!(schema, false) }
+    assert_nothing_raised { validate_simple!(schema, true) }
+    assert_nothing_raised { validate_simple!(schema, false) }
 
     assert_failed_validation('at . expected type boolean, got int with value 1') do
       validate!(schema, 1)
@@ -69,12 +83,21 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation('at . expected type boolean, got null') do
       validate!(schema, nil)
     end
+
+    assert_failed_validation('at . expected type boolean, got int with value 1') do
+      validate_simple!(schema, 1)
+    end
+
+    assert_failed_validation('at . expected type boolean, got null') do
+      validate_simple!(schema, nil)
+    end
   end
 
   def test_fixed_size_string
     schema = hash_to_schema(type: 'fixed', name: 'some', size: 3)
 
     assert_nothing_raised { validate!(schema, 'baf') }
+    assert_nothing_raised { validate_simple!(schema, 'baf') }
 
     assert_failed_validation('at . expected fixed with size 3, got "some" with size 4') do
       validate!(schema, 'some')
@@ -83,30 +106,38 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation('at . expected fixed with size 3, got null') do
       validate!(schema, nil)
     end
+
+    assert_failed_validation('at . expected fixed with size 3, got "some" with size 4') do
+      validate_simple!(schema, 'some')
+    end
+
+    assert_failed_validation('at . expected fixed with size 3, got null') do
+      validate_simple!(schema, nil)
+    end
   end
 
   def test_original_validate_nil
     schema = hash_to_schema(type: 'null', name: 'name')
 
-    assert_valid_schema(schema, [nil], ['something'])
+    assert_valid_schema(schema, [nil], ['something'], true)
   end
 
   def test_original_validate_boolean
     schema = hash_to_schema(type: 'boolean', name: 'name')
 
-    assert_valid_schema(schema, [true, false], [nil, 1])
+    assert_valid_schema(schema, [true, false], [nil, 1], true)
   end
 
   def test_validate_string
     schema = hash_to_schema(type: 'string', name: 'name')
 
-    assert_valid_schema(schema, ['string'], [nil, 1])
+    assert_valid_schema(schema, ['string'], [nil, 1], true)
   end
 
   def test_validate_bytes
     schema = hash_to_schema(type: 'bytes', name: 'name')
 
-    assert_valid_schema(schema, ['string'], [nil, 1])
+    assert_valid_schema(schema, ['string'], [nil, 1], true)
   end
 
   def test_validate_int
@@ -115,41 +146,45 @@ class TestSchema < Test::Unit::TestCase
     assert_valid_schema(
       schema,
       [Avro::Schema::INT_MIN_VALUE, Avro::Schema::INT_MAX_VALUE, 1],
-      [Avro::Schema::LONG_MIN_VALUE, Avro::Schema::LONG_MAX_VALUE, 'string']
+      [Avro::Schema::LONG_MIN_VALUE, Avro::Schema::LONG_MAX_VALUE, 'string'],
+      true
     )
     assert_failed_validation('at . out of bound value 9223372036854775807') do
       validate!(schema, Avro::Schema::LONG_MAX_VALUE)
+    end
+    assert_failed_validation('at . out of bound value 9223372036854775807') do
+      validate_simple!(schema, Avro::Schema::LONG_MAX_VALUE)
     end
   end
 
   def test_validate_long
     schema = hash_to_schema(type: 'long', name: 'name')
 
-    assert_valid_schema(schema, [Avro::Schema::LONG_MIN_VALUE, Avro::Schema::LONG_MAX_VALUE, 1], [1.1, 'string'])
+    assert_valid_schema(schema, [Avro::Schema::LONG_MIN_VALUE, Avro::Schema::LONG_MAX_VALUE, 1], [1.1, 'string'], true)
   end
 
   def test_validate_float
     schema = hash_to_schema(type: 'float', name: 'name')
 
-    assert_valid_schema(schema, [1.1, 1, Avro::Schema::LONG_MAX_VALUE], ['string'])
+    assert_valid_schema(schema, [1.1, 1, Avro::Schema::LONG_MAX_VALUE], ['string'], true)
   end
 
   def test_validate_double
     schema = hash_to_schema(type: 'double', name: 'name')
 
-    assert_valid_schema(schema, [1.1, 1, Avro::Schema::LONG_MAX_VALUE], ['string'])
+    assert_valid_schema(schema, [1.1, 1, Avro::Schema::LONG_MAX_VALUE], ['string'], true)
   end
 
   def test_validate_fixed
     schema = hash_to_schema(type: 'fixed', name: 'name', size: 3)
 
-    assert_valid_schema(schema, ['abc'], ['ab', 1, 1.1, true])
+    assert_valid_schema(schema, ['abc'], ['ab', 1, 1.1, true], true)
   end
 
   def test_validate_original_num
     schema = hash_to_schema(type: 'enum', name: 'name', symbols: %w(a b))
 
-    assert_valid_schema(schema, ['a', 'b'], ['c'])
+    assert_valid_schema(schema, ['a', 'b'], ['c'], true)
   end
 
   def test_validate_record
@@ -164,22 +199,22 @@ class TestSchema < Test::Unit::TestCase
     )
 
     assert_nothing_raised { validate!(schema, 'sub' => 1) }
+    assert_nothing_raised { validate_simple!(schema, 'sub' => 1) }
 
     assert_failed_validation('at .sub expected type int, got null') do
       validate!(schema, {})
     end
+    assert_nothing_raised { validate_simple!(schema, {}) }
 
     assert_failed_validation('at . expected type record, got float with value 1.2') do
       validate!(schema, 1.2)
     end
+    assert_nothing_raised { validate_simple!(schema, 1.2) }
 
     assert_failed_validation('at .sub expected type int, got float with value 1.2') do
       validate!(schema, 'sub' => 1.2)
     end
-
-    assert_failed_validation('at .sub expected type int, got null') do
-      validate!(schema, {})
-    end
+    assert_nothing_raised { validate_simple!(schema, 'sub' => 1.2) }
   end
 
   def test_validate_array
@@ -188,18 +223,22 @@ class TestSchema < Test::Unit::TestCase
                             items: [{ type: 'int', name: 'height' }])
 
     assert_nothing_raised { validate!(schema, []) }
+    assert_nothing_raised { validate_simple!(schema, []) }
 
     assert_failed_validation 'at . expected type array, got null' do
       validate!(schema, nil)
     end
+    assert_nothing_raised { validate_simple!(schema, nil) }
 
     assert_failed_validation('at .[0] expected type int, got null') do
       validate!(schema, [nil])
     end
+    assert_nothing_raised { validate_simple!(schema, [nil]) }
 
     assert_failed_validation('at .[3] expected type int, got string with value "so wrong"') do
       validate!(schema, [1, 3, 9, 'so wrong'])
     end
+    assert_nothing_raised { validate_simple!(schema, [1, 3, 9, 'so wrong']) }
   end
 
   def test_validate_enum
@@ -208,9 +247,14 @@ class TestSchema < Test::Unit::TestCase
                             symbols: %w(one two three))
 
     assert_nothing_raised { validate!(schema, 'one') }
+    assert_nothing_raised { validate_simple!(schema, 'one') }
 
     assert_failed_validation('at . expected enum with values ["one", "two", "three"], got string with value "five"') do
       validate!(schema, 'five')
+    end
+
+    assert_failed_validation('at . expected enum with values ["one", "two", "three"], got string with value "five"') do
+      validate_simple!(schema, 'five')
     end
   end
 
@@ -226,6 +270,8 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation('at .what_ever expected union of [\'long\', \'string\'], got null') {
       validate!(schema, 'what_ever' => nil)
     }
+
+    assert_nothing_raised { validate_simple!(schema, 'what_ever' => nil) }
   end
 
   def test_validate_union_of_nil_and_record_inside_array
@@ -267,22 +313,29 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation('at .person expected type record, got null') {
       validate!(schema, 'not at all' => nil)
     }
+    assert_nothing_raised { validate_simple!(schema, 'not at all' => nil) }
+
     assert_nothing_raised { validate!(schema, 'person' => {}) }
     assert_nothing_raised { validate!(schema, 'person' => { houses: [] }) }
     assert_nothing_raised { validate!(schema, 'person' => { 'houses' => [{ 'number_of_rooms' => 1 }] }) }
 
+    assert_nothing_raised { validate_simple!(schema, 'person' => {}) }
+    assert_nothing_raised { validate_simple!(schema, 'person' => { houses: [] }) }
+    assert_nothing_raised { validate_simple!(schema, 'person' => { 'houses' => [{ 'number_of_rooms' => 1 }] }) }
+
     message = 'at .person.houses[1].number_of_rooms expected type long, got string with value "not valid at all"'
+    datum = {
+      'person' => {
+        'houses' => [
+          { 'number_of_rooms' => 2 },
+          { 'number_of_rooms' => 'not valid at all' }
+        ]
+      }
+    }
     assert_failed_validation(message) do
-      validate!(
-        schema,
-        'person' => {
-          'houses' => [
-            { 'number_of_rooms' => 2 },
-            { 'number_of_rooms' => 'not valid at all' }
-          ]
-        }
-      )
+      validate!(schema, datum)
     end
+    assert_nothing_raised { validate_simple!(schema, datum) }
   end
 
   def test_validate_map
@@ -293,14 +346,17 @@ class TestSchema < Test::Unit::TestCase
                             ])
 
     assert_nothing_raised { validate!(schema, 'some' => 1) }
+    assert_nothing_raised { validate_simple!(schema, 'some' => 1) }
 
     assert_failed_validation('at .some expected type int, got string with value "nope"') do
       validate!(schema, 'some' => 'nope')
     end
+    assert_nothing_raised { validate_simple!(schema, 'some' => 'nope') }
 
     assert_failed_validation("at . unexpected key type 'Symbol' in map") do
       validate!(schema, some: 1)
     end
+    assert_nothing_raised { validate_simple!(schema, some: 1) }
   end
 
   def test_validate_deep_record
@@ -332,22 +388,27 @@ class TestSchema < Test::Unit::TestCase
                             ])
 
     assert_nothing_raised { validate!(schema, 'head' => { 'hair' => { 'color' => 'black' } }) }
+    assert_nothing_raised { validate_simple!(schema, 'head' => { 'hair' => { 'color' => 'black' } }) }
 
     assert_failed_validation('at .head.hair.color expected type string, got null') do
       validate!(schema, 'head' => { 'hair' => { 'color' => nil } })
     end
+    assert_nothing_raised { validate_simple!(schema, 'head' => { 'hair' => { 'color' => nil } }) }
 
     assert_failed_validation('at .head.hair.color expected type string, got null') do
       validate!(schema, 'head' => { 'hair' => {} })
     end
+    assert_nothing_raised { validate_simple!(schema, 'head' => { 'hair' => {} }) }
 
     assert_failed_validation('at .head.hair expected type record, got null') do
       validate!(schema, 'head' => {})
     end
+    assert_nothing_raised { validate_simple!(schema, 'head' => {}) }
 
     assert_failed_validation('at . expected type record, got null') do
       validate!(schema, nil)
     end
+    assert_nothing_raised { validate_simple!(schema, nil) }
   end
 
   def test_validate_deep_record_with_array
@@ -373,14 +434,17 @@ class TestSchema < Test::Unit::TestCase
                               }
                             ])
     assert_nothing_raised { validate!(schema, 'fruits' => [{ 'name' => 'apple', 'weight' => 30.2 }]) }
+    assert_nothing_raised { validate_simple!(schema, 'fruits' => [{ 'name' => 'apple', 'weight' => 30.2 }]) }
 
     assert_failed_validation('at .fruits[0].name expected type string, got null') do
       validate!(schema, 'fruits' => [{ 'name' => nil, 'weight' => 30.2 }])
     end
+    assert_nothing_raised { validate_simple!(schema, 'fruits' => [{ 'name' => nil, 'weight' => 30.2 }]) }
 
     assert_failed_validation('at .fruits expected type array, got int with value 1') do
       validate!(schema, 'fruits' => 1)
     end
+    assert_nothing_raised { validate_simple!(schema, 'fruits' => 1) }
   end
 
   def test_validate_multiple_errors
@@ -393,6 +457,7 @@ class TestSchema < Test::Unit::TestCase
     exception = assert_raise(Avro::SchemaValidator::ValidationError) do
       validate!(schema, [nil, 'e'])
     end
+    assert_nothing_raised { validate_simple!(schema, [nil, 'e']) }
     assert_equal 2, exception.result.errors.size
     assert_equal(
       "at .[0] expected type int, got null\nat .[1] expected type int, got string with value \"e\"",


### PR DESCRIPTION
Prior to this change `Avro::IO::DatumWriter#write_data` performed recursive validation of the datum to be encoded against the schema. 

However, the encoding of complex fields (record, array, map, union) all made subsequent calls to `#write_data` that recursively validated the same datum again. As a result complex types were validated multiple types based on their level of nesting.

This change introduces an `Avro::Schema.validate_simple` method which only validates the non-complex fields that appear at a given level. `#write_data` is modified to call this new method, so that fields are each validated once, then they are encoded. 

The implementation of `.validate_recursive!` in `Avro::SchemaValidator` is refactored so that the implementation of `.validate_simple` is also reused in that context.

I will submit this change in some form back to the original Avro project, likely combined with the previous performance change. Here I have made the changes to the existing of the patches in this gem, but based on the form in which this gets submitted I may eventually refactor the layering here so that it reflects the submitted patch.

The specs are also updated here to show that `Avro::SchemaValidator.validate_simple!` returns all of the validation errors that were previously returned by `Avro::SchemaValidator.validate!` for simple types, and it returns no validation errors for complex types.

Prime: @jturkel 