### PR TITLE
Add change from Avro master to ensure string encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.0
 - Further performance improvements for `Avro::SchemaValidator` and encoding.
+- Ensure that strings are encoded as UTF-8.
 
 ## v0.2.0
 - Performance improvements for `Avro::SchemaValidator`.

--- a/lib/avro-patches.rb
+++ b/lib/avro-patches.rb
@@ -1,6 +1,7 @@
 require 'avro-patches/version'
 
 require 'avro'
+require 'avro-patches/ensure_encoding'
 require 'avro-patches/schema_validator'
 require 'avro-patches/logical_types'
 require 'avro-patches/schema_compatibility'

--- a/lib/avro-patches/ensure_encoding.rb
+++ b/lib/avro-patches/ensure_encoding.rb
@@ -1,0 +1,5 @@
+# Change from "AVRO-1783: Ruby: Ensure correct binary encoding for byte strings"
+# https://github.com/apache/avro/commit/315d842148d57590a58fafecf6e5ea378e9e0d74
+
+# Only part of the above commit is included as we are not using protocols and RPC
+require_relative 'ensure_encoding/io'

--- a/lib/avro-patches/ensure_encoding/io.rb
+++ b/lib/avro-patches/ensure_encoding/io.rb
@@ -1,0 +1,12 @@
+Avro::IO::DatumWriter.class_eval do
+  # A string is encoded as a long followed by that many bytes of
+  # UTF-8 encoded character data
+  def write_string(datum)
+    # The original commit used:
+    #   datum = datum.encode('utf-8') if datum.respond_to? :encode
+    # This always allocated a new string even if the string was already UTF-8 encoded.
+    # The form below is slightly more efficient.
+    datum = datum.encode(Encoding::UTF_8) if datum.respond_to?(:encode) && datum.encoding != Encoding::UTF_8
+    write_bytes(datum)
+  end
+end

--- a/test/ensure_encoding/test_io.rb
+++ b/test/ensure_encoding/test_io.rb
@@ -1,0 +1,48 @@
+require 'test_help'
+
+class TestEnsureEncodingIO < Test::Unit::TestCase
+  def test_utf8_string_encoding
+    [
+      "\xC3".force_encoding('ISO-8859-1'),
+      "\xC3\x83".force_encoding('UTF-8')
+    ].each do |value|
+      output = ''.force_encoding('BINARY')
+      encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
+      datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse('"string"'))
+      datum_writer.write(value, encoder)
+
+      assert_equal "\x04\xc3\x83".force_encoding('BINARY'), output
+    end
+  end
+
+  def test_bytes_encoding
+    [
+      "\xC3\x83".force_encoding('BINARY'),
+      "\xC3\x83".force_encoding('ISO-8859-1'),
+      "\xC3\x83".force_encoding('UTF-8')
+    ].each do |value|
+      output = ''.force_encoding('BINARY')
+      encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
+      datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse('"bytes"'))
+      datum_writer.write(value, encoder)
+
+      assert_equal "\x04\xc3\x83".force_encoding('BINARY'), output
+    end
+  end
+
+  def test_fixed_encoding
+    [
+      "\xC3\x83".force_encoding('BINARY'),
+      "\xC3\x83".force_encoding('ISO-8859-1'),
+      "\xC3\x83".force_encoding('UTF-8')
+    ].each do |value|
+      output = ''.force_encoding('BINARY')
+      encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
+      schema = '{"type": "fixed", "name": "TwoBytes", "size": 2}'
+      datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse(schema))
+      datum_writer.write(value, encoder)
+
+      assert_equal "\xc3\x83".force_encoding('BINARY'), output
+    end
+  end
+end


### PR DESCRIPTION
I went back and compared the salsify-master branch that we were using for `avro-salsify-fork` to an up-to-date Avro 1.8 branch: https://github.com/salsify/avro/compare/branch-1.8...salsify-master#diff-55aff28408ec3ae66695e71ee222ee89

This identified one difference from the code were using with `avro-salsify-fork` and the initial version of `avro-patches`.

Some of the tests added in the original commit are also copied over.

This PR is against another branch that I have open. 

Prime: @jturkel 
