### PR TITLE
Some additional cleanup

### DIFF
--- a/lib/avro-patches/schema_validator.rb
+++ b/lib/avro-patches/schema_validator.rb
@@ -2,3 +2,4 @@
 # https://github.com/apache/avro/pull/111
 require_relative 'schema_validator/schema_validator'
 require_relative 'schema_validator/schema'
+require_relative 'schema_validator/io'

--- a/lib/avro-patches/schema_validator/io.rb
+++ b/lib/avro-patches/schema_validator/io.rb
@@ -1,0 +1,27 @@
+Avro::IO::DatumWriter.class_eval do
+  def write_data(writers_schema, datum, encoder)
+    unless Avro::Schema.validate(writers_schema, datum, recursive: false)
+      raise Avro::IO::AvroTypeError.new(writers_schema, datum)
+    end
+
+    # function dispatch to write datum
+    case writers_schema.type_sym
+    when :null;    encoder.write_null(datum)
+    when :boolean; encoder.write_boolean(datum)
+    when :string;  encoder.write_string(datum)
+    when :int;     encoder.write_int(datum)
+    when :long;    encoder.write_long(datum)
+    when :float;   encoder.write_float(datum)
+    when :double;  encoder.write_double(datum)
+    when :bytes;   encoder.write_bytes(datum)
+    when :fixed;   write_fixed(writers_schema, datum, encoder)
+    when :enum;    write_enum(writers_schema, datum, encoder)
+    when :array;   write_array(writers_schema, datum, encoder)
+    when :map;     write_map(writers_schema, datum, encoder)
+    when :union;   write_union(writers_schema, datum, encoder)
+    when :record, :error, :request;  write_record(writers_schema, datum, encoder)
+    else
+      raise Avro::AvroError.new("Unknown type: #{writers_schema.type}")
+    end
+  end
+end

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -22,7 +22,7 @@ class TestSchema < Test::Unit::TestCase
   end
 
   def validate_simple!(schema, value)
-    Avro::SchemaValidator.validate!(schema, value, { recursive: false })
+    Avro::SchemaValidator.validate!(schema, value, recursive: false)
   end
 
   def hash_to_schema(hash)
@@ -43,13 +43,13 @@ class TestSchema < Test::Unit::TestCase
   def assert_valid_schema(schema, valid, invalid, simple = false)
     valid.each do |value|
       assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value) }
-      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, { recursive: false }) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, recursive: false) } if simple
     end
 
     invalid.each do |value|
       assert_raise { Avro::SchemaValidator.validate!(schema, value) }
-      assert_raise { Avro::SchemaValidator.validate!(schema, value, false) } if simple
-      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, { recursive: false }) } unless simple
+      assert_raise { Avro::SchemaValidator.validate!(schema, value, recursive: false) } if simple
+      assert_nothing_raised { Avro::SchemaValidator.validate!(schema, value, recursive: false) } unless simple
     end
   end
 


### PR DESCRIPTION
While extracting recent changes to submit to the official Avro project I found a couple of things to cleanup. 

One test was coded incorrectly, passing `false` instead of `recursive: false`. Some other tests still contained unnecessary brackets.

The patch to `Avro::IO::DatumWriter` included here does not change behavior since it is overridden in `logical_types/io`, but its omission broke my plan to keep track of the changes in layers. That layering was useful since I was submitting a patch to master which has the schema validator change, but does not yet include the logical type support.

No release required for these changes.

Prime: @jturkel 