### PR TITLE
Fix references to SchemaParseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-patches
 
+## v0.3.1
+- Fix references to `Avro::SchemaParseError`.
+
 ## v0.3.0
 - Further performance improvements for `Avro::SchemaValidator` and encoding.
 - Ensure that strings are encoded as UTF-8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # avro-patches
 
 ## v0.3.1
-- Fix references to `Avro::SchemaParseError`.
+- Fix references to `Avro::SchemaParseError` and `Avro::UnknownSchemaError`.
 
 ## v0.3.0
 - Further performance improvements for `Avro::SchemaValidator` and encoding.

--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -31,8 +31,6 @@ Avro::Schema.class_eval do
         when :record, :error
           fields = json_obj['fields']
           return Avro::Schema::RecordSchema.new(name, namespace, fields, names, type_sym)
-        else
-          raise Avro::SchemaParseError.new("Unknown named type: #{type}")
         end
 
       else
@@ -52,7 +50,7 @@ Avro::Schema.class_eval do
     elsif Avro::Schema::PRIMITIVE_TYPES.include? json_obj
       return Avro::Schema::PrimitiveSchema.new(json_obj)
     else
-      raise Avro::Schema::UnknownSchemaError.new(json_obj)
+      raise Avro::UnknownSchemaError.new(json_obj)
     end
   end
 

--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -6,12 +6,12 @@ Avro::Schema.class_eval do
     if json_obj.is_a? Hash
       type = json_obj['type']
       logical_type = json_obj['logicalType']
-      raise Avro::Schema::SchemaParseError, %Q(No "type" property: #{json_obj}) if type.nil?
+      raise Avro::SchemaParseError, %Q(No "type" property: #{json_obj}) if type.nil?
 
       # Check that the type is valid before calling #to_sym, since symbols are never garbage
       # collected (important to avoid DoS if we're accepting schemas from untrusted clients)
       unless Avro::Schema::VALID_TYPES.include?(type)
-        raise Avro::Schema::SchemaParseError, "Unknown type: #{type}"
+        raise Avro::SchemaParseError, "Unknown type: #{type}"
       end
 
       type_sym = type.to_sym
@@ -32,7 +32,7 @@ Avro::Schema.class_eval do
           fields = json_obj['fields']
           return Avro::Schema::RecordSchema.new(name, namespace, fields, names, type_sym)
         else
-          raise Avro::Schema::SchemaParseError.new("Unknown named type: #{type}")
+          raise Avro::SchemaParseError.new("Unknown named type: #{type}")
         end
 
       else
@@ -42,7 +42,7 @@ Avro::Schema.class_eval do
         when :map
           return Avro::Schema::MapSchema.new(json_obj['values'], names, default_namespace)
         else
-          raise Avro::Schema::SchemaParseError.new("Unknown Valid Type: #{type}")
+          raise Avro::SchemaParseError.new("Unknown Valid Type: #{type}")
         end
       end
 

--- a/lib/avro-patches/version.rb
+++ b/lib/avro-patches/version.rb
@@ -1,3 +1,3 @@
 module AvroPatches
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/test/logical_types/test_logical_types_schema.rb
+++ b/test/logical_types/test_logical_types_schema.rb
@@ -15,4 +15,36 @@ class TestLogicalTypesSchema < Test::Unit::TestCase
       ]
     }
   end
+
+  def test_real_parse_without_type
+    json_obj = { 'foo' => 'bar' }
+    assert_raise(Avro::SchemaParseError, "No \"type\" property: #{json_obj}") do
+      Avro::Schema.real_parse(json_obj)
+    end
+  end
+
+  def test_real_parse_with_unknown_type
+    assert_raise(Avro::SchemaParseError, "Unknown type: foo") do
+      Avro::Schema.real_parse('type' => 'foo')
+    end
+  end
+
+  def test_real_parse_with_union_type
+    assert_raise(Avro::SchemaParseError, "Unknown Valid Type: union") do
+      Avro::Schema.real_parse('type' => 'union')
+    end
+  end
+
+  def test_real_parse_with_request_type
+    assert_raise(Avro::SchemaParseError, "Unknown Valid Type: request") do
+      Avro::Schema.real_parse('type' => 'request')
+    end
+  end
+
+  def test_real_parse_with_unknown_object
+    object = Object.new
+    assert_raise(Avro::UnknownSchemaError, "#{object} is not a schema we know about") do
+      Avro::Schema.real_parse(object)
+    end
+  end
 end


### PR DESCRIPTION
References to `SchemaParseError` were incorrectly nested under `Avro::Schema`.

This is to fix the issue found in testing https://github.com/salsify/salsify_avro/pull/44

Prime: @jturkel 