### PR TITLE
Replace require 'avro' to fix Ruby 2.4 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-patches
 
+## v0.3.2
+- Fix remaining Ruby 2.4 deprecation notices by replacing `require 'avro'`.
+
 ## v0.3.1
 - Fix references to `Avro::SchemaParseError` and `Avro::UnknownSchemaError`.
 

--- a/lib/avro-patches.rb
+++ b/lib/avro-patches.rb
@@ -1,7 +1,40 @@
 require 'avro-patches/version'
 
-require 'avro'
+# Calling require 'avro' leads to deprecation notices because requiring
+# 'avro/ipc' calls methods that this gem patches.
+#
+# Replicate the require statements from avro.rb so that we can insert
+# patches into the load order:
+
+require 'multi_json'
+require 'set'
+require 'digest/md5'
+require 'net/http'
+require 'stringio'
+require 'zlib'
+
+module Avro
+  class AvroError < StandardError; end
+
+  class AvroTypeError < Avro::AvroError
+    def initialize(schm=nil, datum=nil, msg=nil)
+      msg ||= "Not a #{schm.to_s}: #{datum}"
+      super(msg)
+    end
+  end
+end
+
+require 'avro/schema'
+require 'avro/io'
+require 'avro/schema_normalization'
+
+# insert avro-patches
 require 'avro-patches/ensure_encoding'
 require 'avro-patches/schema_validator'
 require 'avro-patches/logical_types'
 require 'avro-patches/schema_compatibility'
+
+# Remaining requires from the official avro gem
+require 'avro/data_file'
+require 'avro/protocol'
+require 'avro/ipc'

--- a/lib/avro-patches/version.rb
+++ b/lib/avro-patches/version.rb
@@ -1,3 +1,3 @@
 module AvroPatches
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
When using this gem we were still seeing deprecation notices from Ruby 2.4 because when `avro` is loaded parts of the gem, specifically `avro/ipc`, call methods that we subsequently patch.

To workaround this, we replace `require 'avro'` to insert the patches from this gem because patched methods are called by other parts of the official Avro gem.

Prime: @jturkel 