### PR TITLE
Restore basic validation for records, arrays, and maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-patches
 
+## v0.3.3
+- Restore basic validation of records, arrays, and maps before writing.
+- Add validation to protect against nil value for map.
+
 ## v0.3.2
 - Fix remaining Ruby 2.4 deprecation notices by replacing `require 'avro'`.
 

--- a/lib/avro-patches/schema_validator/io.rb
+++ b/lib/avro-patches/schema_validator/io.rb
@@ -25,3 +25,26 @@ Avro::IO::DatumWriter.class_eval do
     end
   end
 end
+
+module AvroPatches
+  module SchemaValidator
+    module IOPatches
+      def write_record(writers_schema, datum, encoder)
+        raise Avro::IO::AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
+        super
+      end
+
+      def write_array(writers_schema, datum, encoder)
+        raise Avro::IO::AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Array)
+        super
+      end
+
+      def write_map(writers_schema, datum, encoder)
+        raise Avro::IO::AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
+        super
+      end
+    end
+  end
+end
+
+Avro::IO::DatumWriter.prepend(AvroPatches::SchemaValidator::IOPatches)

--- a/lib/avro-patches/schema_validator/schema_validator.rb
+++ b/lib/avro-patches/schema_validator/schema_validator.rb
@@ -157,6 +157,7 @@ module Avro
       end
 
       def validate_map(expected_schema, datum, path, result)
+        fail TypeMismatchError unless datum.is_a?(Hash)
         datum.keys.each do |k|
           result.add_error(path, "unexpected key type '#{ruby_to_avro_type(k.class)}' in map") unless k.is_a?(String)
         end

--- a/lib/avro-patches/version.rb
+++ b/lib/avro-patches/version.rb
@@ -1,3 +1,3 @@
 module AvroPatches
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -356,7 +356,12 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation("at . unexpected key type 'Symbol' in map") do
       validate!(schema, some: 1)
     end
-    assert_nothing_raised { validate_simple!(schema, some: 1) }
+    assert_nothing_raised { validate_simple!(schema,nil) }
+
+    assert_failed_validation('at . expected type map, got null') do
+      validate!(schema, nil)
+    end
+    assert_nothing_raised { validate_simple!(schema, nil) }
   end
 
   def test_validate_deep_record

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -356,7 +356,7 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation("at . unexpected key type 'Symbol' in map") do
       validate!(schema, some: 1)
     end
-    assert_nothing_raised { validate_simple!(schema,nil) }
+    assert_nothing_raised { validate_simple!(schema, nil) }
 
     assert_failed_validation('at . expected type map, got null') do
       validate!(schema, nil)

--- a/test/schema_validator/test_schema_validator_io.rb
+++ b/test/schema_validator/test_schema_validator_io.rb
@@ -1,0 +1,34 @@
+require 'test_help'
+
+class TestSchemaValidatorIO < Test::Unit::TestCase
+  def test_record_with_nil
+    schema = Avro::Schema.parse('{"type":"record", "name":"rec", "fields":[{"type":"int", "name":"i"}]}')
+    assert_raise(Avro::IO::AvroTypeError) do
+      write_datum(nil, schema)
+    end
+  end
+
+  def test_array_with_nil
+    schema = Avro::Schema.parse('{"type":"array", "items":"int"}')
+    assert_raise(Avro::IO::AvroTypeError) do
+      write_datum(nil, schema)
+    end
+  end
+
+  def test_map_with_nil
+    schema = Avro::Schema.parse('{"type":"map", "values":"long"}')
+    assert_raise(Avro::IO::AvroTypeError) do
+      write_datum(nil, schema)
+    end
+  end
+
+  # helper
+
+  def write_datum(datum, writers_schema)
+    writer = StringIO.new
+    encoder = Avro::IO::BinaryEncoder.new(writer)
+    datum_writer = Avro::IO::DatumWriter.new(writers_schema)
+    datum_writer.write(datum, encoder)
+    writer
+  end
+end


### PR DESCRIPTION
When I added encoding performance improvements by skipping recursive validation prior to encoding, some basic checks were lost (e.g. a record is a Hash, an array is an Array, etc).

Encoding is performed recursively, so in keeping with that the relevant validation is restored by adding the basic checks to the `write_*` methods.

Additionally when performing recursive validation, there was no check that a Hash was passed for a map-type.

Each of these changes are primarily to protect against calling methods on nil, and to raise an `Avro::IO::AvroTypeError` that can be caught instead.

Once these changes are reviewed I'll port them into the official Avro PR: https://github.com/apache/avro/pull/230

@jkapell Can you take a look at this?