### PR TITLE
Allow nested records to be promoted to unions containing a compatible record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
+*.iml

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 set -v
 
-bundle update
+gem install bundler && bundle update
 
 overcommit --install

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -v
 
-gem install bundler && bundle update
+gem install bundler
+bundle update
 
 overcommit --install

--- a/lib/avro-patches/schema_compatibility/schema_compatibility.rb
+++ b/lib/avro-patches/schema_compatibility/schema_compatibility.rb
@@ -124,9 +124,7 @@ module Avro
       def match_record_schemas(writers_schema, readers_schema)
         case writers_schema.type_sym
         when :union
-          # find the first schema in the writer's union that matches the reader record's name
-          matching_union_member = writers_schema.schemas.select { |schema| schema.type_sym == :record && schema.name == readers_schema.name }.first
-          return false unless !matching_union_member.nil? && full_match_schemas(matching_union_member, readers_schema)
+          return false
         else
           writer_fields_hash = writers_schema.fields_hash
           readers_schema.fields.each do |field|

--- a/test/schema_compatibility/test_schema_compatibility.rb
+++ b/test/schema_compatibility/test_schema_compatibility.rb
@@ -61,7 +61,7 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
       null_schema, null_schema,
 
-      nested_nullable_record, nested_record  # (null, foo) is the superset of (foo)
+      nested_optional_record, nested_record  # (null, foo) is the superset of (foo)
 
     ].each_slice(2) do |(reader, writer)|
       assert_true(can_read?(writer, reader), "expecting #{reader} to read #{writer}")
@@ -74,6 +74,7 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
   def test_incompatible_reader_writer_pairs
     [
+
       null_schema, int_schema,
       null_schema, long_schema,
 
@@ -119,8 +120,8 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
       null_schema, int_schema,
 
-      nested_record, nested_nullable_record, # can't null the unnullable
-      
+      nested_record, nested_optional_record, # can't null the unnullable
+
     ].each_slice(2) do |(reader, writer)|
       assert_false(can_read?(writer, reader), "expecting #{reader} not to read #{writer}")
     end
@@ -407,7 +408,7 @@ class TestSchemaCompatibility < Test::Unit::TestCase
     Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}}]}')
   end
 
-  def nested_nullable_record
+  def nested_optional_record
     Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":["null",{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}],"default":null}]}')
   end
 

--- a/test/schema_compatibility/test_schema_compatibility.rb
+++ b/test/schema_compatibility/test_schema_compatibility.rb
@@ -59,7 +59,10 @@ class TestSchemaCompatibility < Test::Unit::TestCase
       long_list_record_schema, long_list_record_schema,
       long_list_record_schema, int_list_record_schema,
 
-      null_schema, null_schema
+      null_schema, null_schema,
+
+      nested_nullable_record, nested_record  # (null, foo) is the superset of (foo)
+
     ].each_slice(2) do |(reader, writer)|
       assert_true(can_read?(writer, reader), "expecting #{reader} to read #{writer}")
     end
@@ -114,7 +117,10 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
       int_list_record_schema, long_list_record_schema,
 
-      null_schema, int_schema
+      null_schema, int_schema,
+
+      nested_record, nested_nullable_record, # can't null the unnullable
+      
     ].each_slice(2) do |(reader, writer)|
       assert_false(can_read?(writer, reader), "expecting #{reader} not to read #{writer}")
     end
@@ -395,6 +401,14 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
   def a_dint_b_dint_record1_schema
     Avro::Schema.parse('{"type":"record", "name":"Record1", "fields":[{"name":"a", "type":"int", "default":0}, {"name":"b", "type":"int", "default":0}]}')
+  end
+
+  def nested_record
+    Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}}]}')
+  end
+
+  def nested_nullable_record
+    Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":["null",{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}],"default":null}]}')
   end
 
   def int_list_record_schema


### PR DESCRIPTION
Previously comparing a nested record to a union failed with a method not found error (`fields_hash` on `writers_schema`). This comparison should not crash and is valid according to http://avro.apache.org/docs/current/spec.html#Schema+Resolution. 

I've added tests and fixes for this error. Additionally I've added a simple fix for the `bin/setup` script so it installs `bundler` and a a `.gitignore` to ignore IntelliJ's project files.

I've tested the migration path (record to union(record, ...) with [Avromatic](https://github.com/salsify/avromatic) and it works correctly.

@jturkel prime