### PR TITLE
Fail when defaults do not match schema type

### DIFF
--- a/lib/avro-patches/logical_types/schema.rb
+++ b/lib/avro-patches/logical_types/schema.rb
@@ -108,3 +108,18 @@ Avro::Schema::FixedSchema.class_eval do
     @size = size
   end
 end
+
+Avro::Schema::Field.class_eval do
+  def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil)
+    @type = subparse(type, names, namespace)
+    @name = name
+    @default = default
+    @order = order
+    begin
+      Avro::SchemaValidator.validate!(@type, @default) if default?
+    rescue Avro::SchemaValidator::ValidationError => e
+      raise Avro::SchemaParseError, "Error validating default for #{name}: #{e.message}"
+    end
+  end
+
+end

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -469,4 +469,41 @@ class TestSchema < Test::Unit::TestCase
       exception.to_s
     )
   end
+
+  def test_validate_defaults
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+                 type: 'record',
+                 name: 'fruits',
+                 fields: [
+                   {
+                     name: 'veggies',
+                     type: 'string',
+                     default: nil
+                   }
+                       ]
+      )
+    end
+    assert_equal("Error validating default for veggies: at . expected type string, got null",
+                 exception.to_s)
+  end
+
+  def test_validate_union_defaults
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+               type: 'record',
+               name: 'fruits',
+               fields: [
+                 {
+                   name: 'veggies',
+                   type: %w(string null),
+                   default: 5
+                 }
+                     ]
+      )
+    end
+    assert_equal("Error validating default for veggies: at . expected union of ['string', 'null'], got int with value 5",
+                 exception.to_s)
+  end
+
 end


### PR DESCRIPTION
Currently, the schema validator allows the following case:
* Schema type is e.g. string
* Default for the schema is set to something other than string, like null or an integer

This will pass without complaint.

This PR adds a validation for default values when registering a schema, indicating that the schema itself is invalid.