### PR TITLE
Fail when extra fields are in the payload

### DIFF
--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -39,11 +39,10 @@ module AvroPatches
             validate_recursive(field.type, datum[field.name], deeper_path, result)
           end
           if options[:fail_on_extra_fields]
-            datum.each_key do |field_name|
-              if expected_schema.fields.find { |f| f.name == field_name.to_s }.nil?
-                result.add_error(path,
-                                 "extra field provided: #{field_name} - not in schema!")
-              end
+            datum_fields = datum.keys.map(&:to_s)
+            schema_fields = expected_schema.fields.map(&:name)
+            (datum_fields - schema_fields).each do |extra_field|
+              result.add_error(path, "extra field '#{extra_field}' - not in schema")
             end
           end
         end

--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -36,6 +36,12 @@ module AvroPatches
             deeper_path = deeper_path_for_hash(field.name, path)
             validate_recursive(field.type, datum[field.name], deeper_path, result)
           end
+          datum.each_key do |field_name|
+            if expected_schema.fields.find { |f| f.name == field_name.to_s }.nil?
+              result.add_error(path,
+                               "extra field provided: #{field_name} - not in schema!")
+            end
+          end
         end
       rescue Avro::SchemaValidator::TypeMismatchError
         result.add_error(path, "expected type #{expected_schema.type_sym}, got #{actual_value_message(datum)}")

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -17,8 +17,8 @@
 require 'test_help'
 
 class TestSchema < Test::Unit::TestCase
-  def validate!(schema, value)
-    Avro::SchemaValidator.validate!(schema, value)
+  def validate!(schema, value, options=nil)
+    Avro::SchemaValidator.validate!(schema, value, options)
   end
 
   def validate_simple!(schema, value)
@@ -310,10 +310,7 @@ class TestSchema < Test::Unit::TestCase
       ]
     )
 
-    assert_failed_validation([
-                               'at .person expected type record, got null',
-                               'at . extra field provided: not at all - not in schema!'
-                             ]) {
+    assert_failed_validation('at .person expected type record, got null') {
       validate!(schema, 'not at all' => nil)
     }
     assert_nothing_raised { validate_simple!(schema, 'not at all' => nil) }
@@ -485,7 +482,7 @@ class TestSchema < Test::Unit::TestCase
                      ]
     )
     exception = assert_raise(Avro::SchemaValidator::ValidationError) do
-      validate!(schema, {'veggies' => 'tomato', 'bread' => 'rye'})
+      validate!(schema, {'veggies' => 'tomato', 'bread' => 'rye'}, fail_on_extra_fields: true)
     end
     assert_equal(1, exception.result.errors.size)
     assert_equal("at . extra field provided: bread - not in schema!",

--- a/test/schema_validator/test_schema_validator.rb
+++ b/test/schema_validator/test_schema_validator.rb
@@ -485,7 +485,7 @@ class TestSchema < Test::Unit::TestCase
       validate!(schema, {'veggies' => 'tomato', 'bread' => 'rye'}, fail_on_extra_fields: true)
     end
     assert_equal(1, exception.result.errors.size)
-    assert_equal("at . extra field provided: bread - not in schema!",
+    assert_equal("at . extra field 'bread' - not in schema",
                  exception.to_s)
   end
 


### PR DESCRIPTION
Currently, when passing a datum into the schema validator, the datum will pass even if the datum has more fields than the schema does. This can be dangerous because the client code is assuming that the schema has these values, but they are actually being silently swallowed when they are encoded.

This PR updates the validator so it will fail if any extra fields are passed into it.