### PR TITLE
Validate that field defaults have the correct type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.0 (unreleased)
 - Optionally fail validation when extra fields are present.
+- Check that field defaults have the correct type.
 
 ## v0.3.4
 - Allow promotion of nested records to optional 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following pending or unreleased changes are included:
 - [AVRO-1969: Add schema compatibility checker for Ruby](https://github.com/apache/avro/pull/170)
 - [AVRO-2039: Ruby encoding performance improvements](https://github.com/apache/avro/pull/230)
 - [AVRO-2200: Option to fail when extra fields are in the payload](https://github.com/apache/avro/pull/321)
+- [AVRO-2199: Validate that field defaults have the correct type](https://github.com/apache/avro/pull/320)
 
 In addition, compatibility with Ruby 2.4 (https://github.com/apache/avro/pull/191)
 has been integrated with the changes above.

--- a/lib/avro-patches.rb
+++ b/lib/avro-patches.rb
@@ -33,6 +33,7 @@ require 'avro-patches/ensure_encoding'
 require 'avro-patches/schema_validator'
 require 'avro-patches/logical_types'
 require 'avro-patches/schema_compatibility'
+require 'avro-patches/default_validation'
 
 # Remaining requires from the official avro gem
 require 'avro/data_file'

--- a/lib/avro-patches/default_validation.rb
+++ b/lib/avro-patches/default_validation.rb
@@ -1,0 +1,1 @@
+require "avro-patches/default_validation/schema"

--- a/lib/avro-patches/default_validation/schema.rb
+++ b/lib/avro-patches/default_validation/schema.rb
@@ -1,0 +1,27 @@
+module AvroPatches
+  module DefaultValidation
+    module FieldPatch
+      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil)
+        super
+
+        validate_default! if default?
+      end
+
+      private
+
+      def validate_default!
+        type_for_default = if type.type_sym == :union
+                             type.schemas.first
+                           else
+                             type
+                           end
+
+        Avro::SchemaValidator.validate!(type_for_default, default)
+      rescue Avro::SchemaValidator::ValidationError => e
+        raise Avro::SchemaParseError, "Error validating default for #{name}: #{e.message}"
+      end
+    end
+  end
+end
+
+Avro::Schema::Field.prepend(AvroPatches::DefaultValidation::FieldPatch)

--- a/test/default_validation/test_default_validation.rb
+++ b/test/default_validation/test_default_validation.rb
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_help'
+
+class TestDefaultValidation < Test::Unit::TestCase
+  def hash_to_schema(hash)
+    Avro::Schema.parse(hash.to_json)
+  end
+
+  def test_validate_defaults
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+        type: 'record',
+        name: 'fruits',
+        fields: [
+          {
+            name: 'veggies',
+            type: 'string',
+            default: nil
+          }
+        ]
+      )
+    end
+    assert_equal('Error validating default for veggies: at . expected type string, got null',
+                 exception.to_s)
+  end
+
+  def test_validate_record_valid_default
+    assert_nothing_raised(Avro::SchemaParseError) do
+      hash_to_schema(
+        type: 'record',
+        name: 'with_subrecord',
+        fields: [
+          {
+            name: 'sub',
+            type: {
+              name: 'subrecord',
+              type: 'record',
+              fields: [
+                { type: 'string', name: 'x' }
+              ]
+            },
+            default: {
+              x: "y"
+            }
+          }
+        ]
+      )
+    end
+  end
+
+  def test_validate_record_invalid_default
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+        type: 'record',
+        name: 'with_subrecord',
+        fields: [
+          {
+            name: 'sub',
+            type: {
+              name: 'subrecord',
+              type: 'record',
+              fields: [
+                { type: 'string', name: 'x' }
+              ]
+            },
+            default: {
+              a: 1
+            }
+          }
+        ]
+      )
+    end
+    assert_equal('Error validating default for sub: at .x expected type string, got null',
+                 exception.to_s)
+  end
+
+  def test_validate_union_defaults
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+        type: 'record',
+        name: 'fruits',
+        fields: [
+          {
+            name: 'veggies',
+            type: %w(string null),
+            default: 5
+          }
+        ]
+      )
+    end
+    assert_equal('Error validating default for veggies: at . expected type string, got int with value 5',
+                 exception.to_s)
+  end
+
+  def test_validate_union_default_first_type
+    exception = assert_raise(Avro::SchemaParseError) do
+      hash_to_schema(
+        type: 'record',
+        name: 'fruits',
+        fields: [
+          {
+            name: 'veggies',
+            type: %w(null string),
+            default: 'apple'
+          }
+        ]
+      )
+    end
+    assert_equal('Error validating default for veggies: at . expected type null, got string with value "apple"',
+                 exception.to_s)
+  end
+end


### PR DESCRIPTION
This is a rearranged form of https://github.com/salsify/avro-patches/pull/14.

I also realized that the Avro spec requires that the default for a union matches the first type in the union so this is now special cased: https://avro.apache.org/docs/1.8.2/spec.html#schema_record

@jkapell - mind taking another look?
CC @dorner 