### PR TITLE
Support values for logical types that were already encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0 (unreleased)
 - Optionally fail validation when extra fields are present.
 - Check that field defaults have the correct type.
+- Support values for logical types that were already encoded.
 
 ## v0.3.4
 - Allow promotion of nested records to optional 

--- a/lib/avro-patches/logical_types/logical_types.rb
+++ b/lib/avro-patches/logical_types/logical_types.rb
@@ -6,6 +6,8 @@ module Avro
       EPOCH_START = Date.new(1970, 1, 1)
 
       def self.encode(date)
+        return date.to_i if date.is_a?(Numeric)
+
         (date - EPOCH_START).to_i
       end
 
@@ -16,6 +18,8 @@ module Avro
 
     module TimestampMillis
       def self.encode(value)
+        return value.to_i if value.is_a?(Numeric)
+
         time = value.to_time
         time.to_i * 1000 + time.usec / 1000
       end
@@ -28,6 +32,8 @@ module Avro
 
     module TimestampMicros
       def self.encode(value)
+        return value.to_i if value.is_a?(Numeric)
+
         time = value.to_time
         time.to_i * 1000_000 + time.usec
       end
@@ -61,7 +67,7 @@ module Avro
     def self.type_adapter(type, logical_type)
       return unless logical_type
 
-      TYPES.fetch(type, {}).fetch(logical_type, Identity)
+      TYPES.fetch(type, {}.freeze).fetch(logical_type, Identity)
     end
   end
 end

--- a/test/logical_types/test_logical_types.rb
+++ b/test/logical_types/test_logical_types.rb
@@ -7,7 +7,9 @@ class TestLogicalTypes < Test::Unit::TestCase
     SCHEMA
 
     assert_equal 'date', schema.logical_type
-    assert_encode_and_decode Date.today, schema
+    today = Date.today
+    assert_encode_and_decode today, schema
+    assert_preencoded Avro::LogicalTypes::IntDate.encode(today), schema, today
   end
 
   def test_int_date_conversion
@@ -28,10 +30,11 @@ class TestLogicalTypes < Test::Unit::TestCase
     SCHEMA
 
     # The Time.at format is (seconds, microseconds) since Epoch.
-    datum = Time.at(628232400, 12000)
+    time = Time.at(628232400, 12000)
 
     assert_equal 'timestamp-millis', schema.logical_type
-    assert_encode_and_decode datum, schema
+    assert_encode_and_decode time, schema
+    assert_preencoded Avro::LogicalTypes::TimestampMillis.encode(time), schema, time.utc
   end
 
   def test_timestamp_millis_long_conversion
@@ -52,10 +55,11 @@ class TestLogicalTypes < Test::Unit::TestCase
     SCHEMA
 
     # The Time.at format is (seconds, microseconds) since Epoch.
-    datum = Time.at(628232400, 12345)
+    time = Time.at(628232400, 12345)
 
     assert_equal 'timestamp-micros', schema.logical_type
-    assert_encode_and_decode datum, schema
+    assert_encode_and_decode time, schema
+    assert_preencoded Avro::LogicalTypes::TimestampMicros.encode(time), schema, time.utc
   end
 
   def test_timestamp_micros_long_conversion
@@ -92,5 +96,10 @@ class TestLogicalTypes < Test::Unit::TestCase
   def assert_encode_and_decode(datum, schema)
     encoded = encode(datum, schema)
     assert_equal datum, decode(encoded, schema)
+  end
+
+  def assert_preencoded(datum, schema, decoded)
+    encoded = encode(datum, schema)
+    assert_equal decoded, decode(encoded, schema)
   end
 end


### PR DESCRIPTION
This fixes #13.

I'll also make sure this gets added to the still open https://github.com/apache/avro/pull/116.