### PR TITLE
Remove bindir to avoid clashes with `bin/console` scripts

### DIFF
--- a/avro-patches.gemspec
+++ b/avro-patches.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 

--- a/avro-patches.gemspec
+++ b/avro-patches.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(bin|test|spec|features)/}) }
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.15'


### PR DESCRIPTION
Since the `bin/console` and `bin/setup` scripts are provided for development purposes, these shouldn't be included in the bindir.

Including it causes issues because it overrides any custom `bin/console` file, for example