### PR TITLE
Feature/strict validation

### DIFF
--- a/lib/avro-patches/logical_types/schema_validator.rb
+++ b/lib/avro-patches/logical_types/schema_validator.rb
@@ -36,7 +36,7 @@ module AvroPatches
           fail Avro::SchemaValidator::TypeMismatchError unless datum.is_a?(Hash)
           expected_schema.fields.each do |field|
             deeper_path = deeper_path_for_hash(field.name, path)
-            validate_recursive(field.type, datum[field.name], deeper_path, result)
+            validate_recursive(field.type, datum[field.name], deeper_path, result, options)
           end
           if options[:fail_on_extra_fields]
             datum_fields = datum.keys.map(&:to_s)


### PR DESCRIPTION
Pull request #15 added strict checking for extra fields, but that only operated at root level. The options were not passed to other validate_*-methods which in turn called validate_recursive again.

This PR updates the validator so it also works on extra fields in nested structures.