### PR TITLE
Optimized binary encoder/decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-patches
 
+## v0.4.1
+- Optimize binary encoder and decoder.
+
 ## v0.4.0
 - Optionally fail validation when extra fields are present.
 - Check that field defaults have the correct type.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following pending or unreleased changes are included:
 - [AVRO-2039: Ruby encoding performance improvements](https://github.com/apache/avro/pull/230)
 - [AVRO-2200: Option to fail when extra fields are in the payload](https://github.com/apache/avro/pull/321)
 - [AVRO-2199: Validate that field defaults have the correct type](https://github.com/apache/avro/pull/320)
+- [AVRO-2281: Optimize ruby binary encoder/decoder](https://github.com/apache/avro/pull/401)
 
 In addition, compatibility with Ruby 2.4 (https://github.com/apache/avro/pull/191)
 has been integrated with the changes above.

--- a/lib/avro-patches.rb
+++ b/lib/avro-patches.rb
@@ -34,6 +34,7 @@ require 'avro-patches/schema_validator'
 require 'avro-patches/logical_types'
 require 'avro-patches/schema_compatibility'
 require 'avro-patches/default_validation'
+require 'avro-patches/optimized_serde'
 
 # Remaining requires from the official avro gem
 require 'avro/data_file'

--- a/lib/avro-patches/optimized_serde.rb
+++ b/lib/avro-patches/optimized_serde.rb
@@ -5,11 +5,34 @@ Avro::IO::BinaryDecoder.class_eval do
   end
 
   def read_float
-    @reader.read(4).unpack1('e'.freeze)
+    read_and_unpack(4, 'e'.freeze)
   end
 
   def read_double
-    @reader.read(8).unpack1('E'.freeze)
+    read_and_unpack(8, 'E'.freeze)
+  end
+
+  def read_string
+    read_bytes.tap do |string|
+      string.force_encoding('utf-8'.freeze) if string.respond_to?(:force_encoding)
+    end
+  end
+
+  private
+
+  # Optimize unpacking strings when `unpack1` is available (ruby >= 2.4)
+  if String.instance_methods.include?(:unpack1)
+
+    def read_and_unpack(byte_count, format)
+      @reader.read(byte_count).unpack1(format)
+    end
+
+  else
+
+    def read_and_unpack(byte_count, format)
+      @reader.read(byte_count).unpack(format)[0]
+    end
+
   end
 end
 
@@ -21,5 +44,10 @@ Avro::IO::BinaryEncoder.class_eval do
 
   def write_double(datum)
     @writer.write([datum].pack('E'.freeze))
+  end
+
+  def write_string(datum)
+    datum = datum.encode('utf-8'.freeze) if datum.respond_to?(:encode)
+    write_bytes(datum)
   end
 end

--- a/lib/avro-patches/optimized_serde.rb
+++ b/lib/avro-patches/optimized_serde.rb
@@ -1,0 +1,25 @@
+Avro::IO::BinaryDecoder.class_eval do
+
+  def byte!
+    @reader.readbyte
+  end
+
+  def read_float
+    @reader.read(4).unpack1('e'.freeze)
+  end
+
+  def read_double
+    @reader.read(8).unpack1('E'.freeze)
+  end
+end
+
+Avro::IO::BinaryEncoder.class_eval do
+
+  def write_float(datum)
+    @writer.write([datum].pack('e'.freeze))
+  end
+
+  def write_double(datum)
+    @writer.write([datum].pack('E'.freeze))
+  end
+end

--- a/lib/avro-patches/version.rb
+++ b/lib/avro-patches/version.rb
@@ -1,3 +1,3 @@
 module AvroPatches
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/test/optimized_serde/test_binary_decoder.rb
+++ b/test/optimized_serde/test_binary_decoder.rb
@@ -1,0 +1,41 @@
+require 'test_help'
+
+class TestBinaryDecoder < Test::Unit::TestCase
+
+  def decode(value, method)
+    string_io = StringIO.new(value)
+    decoder = Avro::IO::BinaryDecoder.new(string_io)
+    decoder.send(method)
+  end
+
+  def encode(value, method)
+    string_io = StringIO.new('', 'w')
+    encoder = Avro::IO::BinaryEncoder.new(string_io)
+    encoder.send(method, value)
+    string_io.string
+  end
+
+  def check_encode_decode(value, type)
+    decode_method = "read_#{type}"
+    encode_method = "write_#{type}"
+    encoded = encode(value, encode_method)
+    decoded = decode(encoded, decode_method)
+    assert_equal(value, decoded)
+  end
+
+  def test_byte!
+    assert_equal([decode('x', :byte!)].pack('c'), 'x')
+  end
+
+  def test_float
+    check_encode_decode(3.0, :float)
+  end
+
+  def test_double
+    check_encode_decode(1.23456789, :double)
+  end
+
+  def test_string
+    check_encode_decode('hello world', :string)
+  end
+end


### PR DESCRIPTION
This makes a couple small tweaks to the binary encoder/decoder to reduce unnecessary allocations. Just calling `readbyte` in `byte!` is ~50% faster. This showed around a 20% performance improvement when decoding complex objects. I'll work on getting this upstream, but figured this is a good place to start.

prime @jturkel